### PR TITLE
Add docker folder

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,8 @@
+TAG=prod
+SERVERNAME=europlanet
+DOMAIN=irap.omp.eu
+DACHS_PORT=80
+AWSTATS_PORT=8080
+PSQL_PORT=5432
+CRONTAB=0 0 * * *
+SERVICE_PATH=./services

--- a/docker/LICENSE
+++ b/docker/LICENSE
@@ -1,0 +1,340 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {description}
+    Copyright (C) {year}  {fullname}
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  {signature of Ty Coon}, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.
+

--- a/docker/awstats/Dockerfile
+++ b/docker/awstats/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:jessie
+
+LABEL Description="AWstats for DaCHS." \
+      Author="Nathanael Jourdane"
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y apache2 awstats cron
+
+# Configure apache2
+RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
+    sed -i.bak "s/\tcreate.*/\tcreate 644 root adm/" /etc/logrotate.d/apache2 && \
+    a2enmod cgid
+
+# TODO: placer tout ça dans startup.sh
+# Edit awstats config file
+RUN sed -i.bak "s/LogFile=.*/LogFile=\"\/usr\/share\/awstats\/tools\/logresolvemerge.pl \/var\/log\/apache2\/access.log\* |\"/;\
+                s/LogFormat=.*/LogFormat=1/;\
+                s/SiteDomain=.*/SiteDomain=\"$SERVERNAME\.$DOMAIN\"/;\
+                s/HostAliases=.*/HostAliases=\"localhost 127\.0\.0\.1 $DOMAIN\"/;\
+                s/DNSLookup=.*/DNSLookup=2/;\
+                s/AllowFullYearView=.*/AllowFullYearView=3/;\
+                s/SkipHosts=.*/SkipHosts=\"145\.238\.187\.13 145\.238\.187\.29\"/" /etc/awstats/awstats.conf
+
+# Edit dachs config file
+RUN cp /etc/awstats/awstats.conf /etc/awstats/awstats.dachs.conf && \
+    sed -i.bak "s/LogFile=.*/LogFile=\"\/usr\/share\/awstats\/tools\/logresolvemerge.pl \/var\/gavo\/logs\/web.log\* |\"/;\
+                s/LogFormat=.*/LogFormat=\"%other %other %other %host %other %other %time1 %methodurl %code %bytesd %refererquot %uaquot\"/;\
+                s/URLWithQuery=.*/URLWithQuery=1/" /etc/awstats/awstats.dachs.conf
+
+RUN echo "#!/bin/bash\n\
+/usr/bin/perl /usr/lib/cgi-bin/awstats.pl -config=dachs -update\n\
+/usr/bin/perl /usr/lib/cgi-bin/awstats.pl -config=apache -update" > /usr/local/bin/run_awstats
+
+# Set files access
+RUN chmod 644 /var/log/apache2/access.log* && \
+    chmod 755 /var/log/apache2 && \
+    chmod 777 /usr/local/bin/run_awstats
+
+# Expose internal web port (actual port is defined by docker-compose)
+EXPOSE 80
+
+# Put site config and startup script files
+COPY site-awstats.conf /etc/apache2/sites-available/000-default.conf
+COPY awstats_startup.sh awstats_startup.sh
+RUN chmod u+x awstats_startup.sh
+
+# All commands (ie. 'command' keyword in docker-compose) will be used as arguments of the startup script
+ENTRYPOINT ["./awstats_startup.sh"]

--- a/docker/awstats/awstats_startup.sh
+++ b/docker/awstats/awstats_startup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "=============== Launching $0 ==============="
+
+CRONTAB=$1
+
+echo "$CRONTAB www-data /usr/local/bin/run_awstats 2>/dev/null" | crontab -u $(id -u -n) -
+service apache2 start
+tail -f var/log/apache2/access.log

--- a/docker/awstats/site-awstats.conf
+++ b/docker/awstats/site-awstats.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+	ScriptAlias /cgi-bin/ /usr/lib/cgi-bin/
+	<Directory "/usr/lib/cgi-bin">
+		Options FollowSymLinks
+		AddHandler cgi-script  .pl
+		AllowOverride None
+		Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+		Order allow,deny
+		Allow from all
+	</Directory>
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/docker/dachs/Dockerfile
+++ b/docker/dachs/Dockerfile
@@ -1,0 +1,53 @@
+FROM debian:jessie
+
+# Dockerfile metadata
+LABEL Description="DaCHS is a publishing infrastructure for the Virtual Observatory." \
+      Author="Markus Demleitner" \
+      URL="http://docs.g-vo.org/DaCHS" \
+      Reference="http://arxiv.org/abs/1408.5733" \
+      maintainer="Nathanael Jourdane <nathanael dot jourdane at irap.omp.eu>"
+
+# Set environment variables
+ENV LANG=C.UTF-8 \
+    DEBIAN_FRONTEND='noninteractive' \
+    LOG_FILE=/var/gavo/logs/web.log \
+    DACHS_TAG=beta
+
+# Install generic dependencies
+RUN apt-get update && \
+    apt-get install -y wget locales
+
+# Install DaCHS
+RUN echo "deb http://vo.ari.uni-heidelberg.de/debian $DACHS_TAG main" > /etc/apt/sources.list.d/gavo.list && \
+    wget -qO - http://docs.g-vo.org/archive-key.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install -y python-gavodachs && \
+    apt-get clean && \
+    # The file describing the epntap2 mixin. Used here only because the DaCHS mixin was obsolete.
+    wget https://raw.githubusercontent.com/epn-vespa/DaCHS-for-VESPA/master/mixin-EPN-TAP-2.0/epntap2.rd-2.xml -O \
+      /usr/lib/python2.7/dist-packages/gavo/resources/inputs/__system__/epntap2.rd
+
+# Among other things, configure users and files access
+RUN echo LANG="$LANG" > /etc/default/locale && \
+    addgroup --system gavo && \
+    adduser --system --ingroup gavo gavo && \
+    adduser --disabled-password --gecos "" --ingroup gavo dachsroot && \
+    adduser --quiet gavo gavo && \
+    adduser --quiet dachsroot gavo && \
+    mkdir -m 775 /var/gavo && \
+    chown dachsroot /var/gavo
+
+# Expose internal web port (actual port is defined by docker-compose)
+EXPOSE 80
+
+# USER gavo
+# WORKDIR /home/gavo
+
+# Update DaCHS config file and startup script on the container
+COPY gavo.rc /etc/gavo.rc
+COPY dachs_startup.sh dachs_startup.sh
+COPY dachs_pub.sh dachs_pub.sh
+RUN chmod u+x dachs_startup.sh dachs_pub.sh
+
+# Run startup script
+CMD ["./dachs_startup.sh"]

--- a/docker/dachs/dachs_pub.sh
+++ b/docker/dachs/dachs_pub.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo "=============== Launching $0 ==============="
+if [ $# != 1 ]; then
+  echo "usage: $0 <service_name>"
+  exit
+fi
+
+SERVICE_NAME=$1
+SERVICE_DIR=/services/$SERVICE_NAME
+INPUT_DIR=/var/gavo/inputs/$SERVICE_NAME
+
+# If needed, you can get the gavoadmin password:
+# PGPASSWORD=$(grep "password = " /var/gavo/etc/feed | cut -d'=' -f 2 | xargs)
+
+echo "Replacing q.rd ..."
+rm -rf $INPUT_DIR && mkdir $INPUT_DIR
+ln -s $SERVICE_DIR/${SERVICE_NAME}_q.rd $INPUT_DIR/q.rd
+ln -s $SERVICE_DIR/${SERVICE_NAME}_pub.py $INPUT_DIR/${SERVICE_NAME}_pub.py
+
+echo "gavo imp..."
+gavo imp $SERVICE_NAME/q
+
+# echo "Executing ${SERVICE}_db.sql in gavo database..."
+# psql -U gavoadmin -h postgres -w gavo < $SERVICE_DIR/${SERVICE_NAME}_db.sql
+# echo "Executing ${SERVICE}_view.sql in gavo database..."
+# psql -U gavoadmin -h postgres -w gavo < $SERVICE_DIR/${SERVICE_NAME}_view.sql
+# echo "gavo imp..."
+# gavo imp -m $INPUT_DIR/q.rd
+
+echo "restating gavo..."
+gavo serve restart
+echo "Done. Service is updated"

--- a/docker/dachs/dachs_startup.sh
+++ b/docker/dachs/dachs_startup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo "=============== Launching $0 ==============="
+
+while ! su - postgres -c "psql -h postgres --quiet gavo -c 'SELECT 1' > /dev/null 2>&1";
+do
+	echo "Waiting for postgres to come up..."
+	echo -n "response: "
+	su - postgres -c "psql -h postgres --quiet gavo -c 'SELECT 1'"
+	sleep 1
+done
+
+echo "gavo init..."
+su dachsroot -c "gavo init -d 'host=postgres dbname=gavo'"
+echo "starting DaCHS..."
+gavo serve start
+
+# Wait for the creation of the DaCHS log file
+sleep 1
+
+echo "DaCHS is running!"
+echo "Displaying log file $LOG_FILE..."
+tail -f $LOG_FILE
+
+# Then:
+# docker-compose up -d --build
+# docker exec -it dachs_prod ./dachs_pub.sh illu67p

--- a/docker/dachs/gavo.rc
+++ b/docker/dachs/gavo.rc
@@ -1,0 +1,4 @@
+[web]
+bindAddress:
+serverPort: 80
+serverURL: http://localhost

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,56 @@
+version: '3'
+
+services:
+
+    dachs:
+        container_name: dachs_${TAG}
+        build: ./dachs
+        tty: true
+        network_mode: 'bridge'
+        ports:
+            - '${DACHS_PORT}:80'
+        volumes:
+            - dachs_data:/var/gavo
+            - ${SERVICE_PATH}:/services
+            # TODO: only /var/gavo/logs/web.log is required no?
+        links:
+            - postgres
+        depends_on:
+            - postgres
+        # TODO: copy observatory logo, cf. https://voparis-confluence.obspm.fr/pages/viewpage.action?pageId=560675
+        # TODO: Add all other DaCHS parameters in .env (such as OV name, etc.)
+
+    postgres:
+        container_name: postgres_${TAG}
+        build: ./postgres
+        tty: true
+        network_mode: 'bridge'
+        ports:
+            - '${PSQL_PORT}:5432'
+        volumes:
+            # TODO: do not use 9.4 here (there is a ENV for psql version in the DaCHS Dockerfile), instead create a symlink in the dockerfile.
+            - postgres_data:/var/lib/postgresql/9.4/main
+
+    awstats:
+        container_name: awstats_${TAG}
+        build: ./awstats
+        environment:
+            - SERVERNAME=${SERVERNAME}
+            - DOMAIN=${DOMAIN}
+        tty: true
+        network_mode: 'bridge'
+        ports:
+            - '${AWSTATS_PORT}:80'
+        volumes:
+            - dachs_data:/var/gavo
+            # TODO: only /var/gavo/logs/web.log is required no?
+            # TODO can we instead use something like volume-from dachs?
+        depends_on:
+            - dachs
+        command:
+            - ${CRONTAB} # The crontab config
+
+# TODO: name volumes for prod and test: http://stackoverflow.com/questions/42952855/env-file-named-volume-in-docker-compose
+volumes:
+    postgres_data:
+    dachs_data:

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,0 +1,53 @@
+FROM debian:jessie
+
+# Dockerfile metadata
+LABEL Description="DaCHS is a publishing infrastructure for the Virtual Observatory." \
+      Author="Markus Demleitner" \
+      URL="http://docs.g-vo.org/DaCHS" \
+      Reference="http://arxiv.org/abs/1408.5733" \
+      maintainer="Nathanael Jourdane <nathanael dot jourdane at irap.omp.eu>"
+
+# Set environment variables
+ENV DEBIAN_FRONTEND='noninteractive' \
+    LANG=C.UTF-8 \
+    PG_VERSION=9.4 \
+    DACHS_TAG=beta
+
+# Set Postgres environment variables (which require $PG_VERSION)
+ENV PGFILE=/etc/postgresql/${PG_VERSION}/main/pg_hba.conf \
+    PGDATA=/var/lib/postgresql/${PG_VERSION} \
+    PGBIN=/usr/lib/postgresql/${PG_VERSION}/bin/postgres \
+    PGCONF=/etc/postgresql/${PG_VERSION}/main/postgresql.conf \
+    PGLOG=/var/log/postgresql/postgresql-${PG_VERSION}-main.log
+# TODO: use LOG_FILE instead of PGLOG
+
+# Install generic dependencies
+RUN apt-get update && \
+    apt-get install -y wget locales
+
+# Install a specific postgresql version and its plugins
+RUN echo "deb http://vo.ari.uni-heidelberg.de/debian $DACHS_TAG main" > /etc/apt/sources.list.d/gavo.list && \
+    echo "deb-src http://vo.ari.uni-heidelberg.de/debian $DACHS_TAG main" >> /etc/apt/sources.list.d/gavo.list && \
+    wget -qO - http://docs.g-vo.org/archive-key.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install -y postgresql-$PG_VERSION postgresql-$PG_VERSION-pgsphere postgresql-$PG_VERSION-q3c && \
+    apt-get clean
+
+# PostgreSQL needs this directory for log files; then some commands to configure PostgreSQL
+RUN mkdir -p -m 777 /var/run/postgresql/${PG_VERSION}-main.pg_stat_tmp/ \
+    echo LANG="$LANG" > /etc/default/locale && \
+    echo 'host  all  all  172.17.0.0/24  trust' >> $PGFILE && \
+    echo "listen_addresses='*'" >> "${PGFILE%/*}/postgresql.conf"
+
+# Expose internal psql port (actual port is defined by docker-compose)
+EXPOSE 5432
+
+# Update startup script
+COPY postgres_startup.sh postgres_startup.sh
+RUN chmod u+x postgres_startup.sh
+
+# Run startup script
+CMD ["./postgres_startup.sh"]
+
+# Then just type:
+# docker exec -it dachs_prod ./dachs_pub.sh <service_name>

--- a/docker/postgres/postgres_startup.sh
+++ b/docker/postgres/postgres_startup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "=============== Launching $0 ==============="
+
+su - postgres -c "$PGBIN -c config_file=$PGCONF -c logging_collector=on" &
+
+while [ $(service postgresql status | cut -d':' -f 2 | xargs) != "online" ];
+do
+	echo "Waiting until postgres is online..."
+	echo -n "status: "
+	service postgresql status
+	sleep 1
+done
+echo "Postgres is now online."
+
+echo "Creating user..."
+su postgres -c "createuser -s dachsroot"
+echo "Creating database..."
+su postgres -c "createdb gavo"
+
+echo "Postgres is functional!"
+echo "Displaying log file $PGLOG..."
+tail -f $PGLOG

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -1,0 +1,136 @@
+# Running DaCHS environment with Docker
+
+## Presentation
+
+This folder aims to provide a complete environment to serve epntap services through DaCHS software, by building 3 docker images:
+- the `dachs` container, running the DaCHS software;
+- the `postgres` container, running the epntap database;
+- the `awstats` container, running AWStats in order to provide statistics about your services.
+
+This images are built from the [docker-compose](docker-compose.yml) file.
+
+## env file
+
+This project is developped with in mind that the only file you have to edit is the [.env](.env) configuration file:
+
+- `TAG` : the tag of you containers; this allow you to build several instances of DaCHS containers, in order to have - for instance - a production container and a test container;
+- `SERVERNAME` : The server name;
+- `DOMAIN` : The server domain;
+- `DACHS_PORT` : The web port used by the DaCHS software;
+- `AWSTATS_PORT` : The web port used by awstats;
+- `PSQL_PORT` : The port used by Postgres (i.e. if you want to access it from PGAdmin);
+- `CRONTAB` : the [crontab string](http://www.nncron.ru/help/EN/working/cron-format.htm) used to update awstats statistics;
+- `SERVICE_PATH` : The (absolute or relative) path of your services folder;
+
+## Setting up Docker
+
+1. Install [Docker](https://docs.docker.com/engine/installation/);
+2. And [Docker-compose](https://docs.docker.com/compose/install/);
+3. and then [configure some other things](https://docs.docker.com/engine/installation/linux/linux-postinstall/).
+
+Depending on your network, you may want to configure the DNS used by Docker:
+
+First, check if you need it:
+
+	docker run -it debian /bin/bash # Dowload the Debian image, run the container and a shell
+	ping 128.31.0.62 # Debian archives IP
+
+You should received all packets. But then ping it from the domain name:
+
+	ping deb.debian.org # Debian archives URL
+
+**If you don't receive the packet, you must configure the Docker DNS**, by add `--dns` option when starting the Docker daemon.
+
+> **Note:** To know the DNS server used on you machine, type:
+>
+>     nmcli device show <network_name> # example : "enp0s25"
+
+**First case: your system uses `systemd`:**
+
+	sudo nano /lib/systemd/system/docker.service
+
+Look for the line begining with `ExecStart` and add the dns options, for example:
+
+	ExecStart=/usr/bin/dockerd -H fd:// --dns=10.10.131.1 --dns=10.10.131.2
+
+**Second case: Your system doesn't use systemd:**
+
+Just add the key `DOCKER_OPTS` in the file `/etc/default/docker`:
+
+	sudo bash -c "echo 'DOCKER_OPTS=\"--dns 8.8.8.8 --dns 8.8.4.4\"' >> /etc/default/docker"
+
+## Setting up your containers
+
+1. Edit your [.env](.env) file as described above;
+2. Put your services in the *services* folder (described in the `.env` file), with one folder by service;
+3. Build the containers with `docker-compose up` command;
+4. Check if DaCHS and awstats are running on `127.0.0.1:<port_specified_in_env_file>`.
+
+> **Note:** you can also do step `3.` with: `docker-compose up -d`, in this way you keep you terminal open to run other commands such as `docker exec`. You can then log a container with `docker logs <container_name>`.
+
+# Filling data
+
+Just execute the `dachs_pub.sh` script from the dachs container:
+
+	docker exec -it <container_name> ./dachs_pub.sh <service_name>
+
+## Hacking your containers
+
+If you want to do some things in a container (for test purposes), type:
+
+	docker exec -it dachs_prod /bin/bash
+
+Note that the Docker philosophy is to don't have to touch a container once it is built. **If you need permanent changes, you must edit your DockerFile** ([this one](dachs/DockerFile), [this one](postgres/DockerFile) or [this one](awstats/DockerFile)).
+
+Each time you modify your Dockerfile, you need to remove the old images and build again you images:
+
+For example if you edit the `dachs` Dockerfile:
+
+	docker rm dachs_prod
+	docker-compose up --build
+
+If you think your modification could be useful for others, please [post a new issue](https://github.com/epn-vespa/DaCHS-for-VESPA/issues).
+
+## DaCHS update
+
+Since Docker build images using layers (it build the image only from where the the Dockerfile has been edited), if the DaCHS software has been updated, you need to remove the Docker images and rebuild them:
+
+	docker rmi dachs_prod postgres_prod
+	Docker-compose up
+
+Note that the Dockerfile replaces the DaCHS epntap2 mixin by [its last version](https://raw.githubusercontent.com/epn-vespa/DaCHS-for-VESPA/master/mixin-EPN-TAP-2.0/epntap2.rd-2.xml) published in the VESPA GitHub.
+
+# Complete workflow example
+
+Prerequies : [Docker and docker-compose are installed and configured](#setting-up-your-containers).
+
+First, clone the DaCHS-for-VESPA from GitHub:
+
+	git clone https://github.com/epn-vespa/DaCHS-for-VESPA.git
+	cd DaCHS-for-VESPA/docker
+
+Now let's try to publish the [illu67 service](https://github.com/epn-vespa/DaCHS-for-VESPA/tree/master/q.rd_examples/illu67p).
+
+	mkdir services
+	cp -r ../q.rd_examples/illu67p/ ./services/illu67p/
+
+The *services* folder should be like this:
+
+	└── services
+	    └── illu67p
+	        ├── illu67p_pub.py
+	        └── illu67p_q.rd
+
+Now build you docker images:
+
+	docker-compose up
+
+When you see `dachs_prod  | DaCHS is running!`, open a new terminal and type
+
+	docker exec -it dachs_prod ./dachs_pub.sh illu67p
+
+When the data are imported, check the [table information page](http://127.0.0.1/__system__/dc_tables/show/tableinfo/illu67p.epn_core) and the go to the [ADQL form page](http://localhost/__system__/adql/query/form) and type:
+
+	select top 10 * from illu67p.epn_core
+
+Is it working? Congration!!! You can now publish you own service.


### PR DESCRIPTION
This folder aims to provide a complete environment to serve epntap services through DaCHS software, by building 3 docker images:
- the `dachs` container, running the DaCHS software;
- the `postgres` container, running the epntap database;
- the `awstats` container, running AWStats in order to provide statistics about your services.

This images are built from the `docker-compose` file.